### PR TITLE
Bugfix for changing targets

### DIFF
--- a/lua/autorun/server/ttttargetserverhit.lua
+++ b/lua/autorun/server/ttttargetserverhit.lua
@@ -163,5 +163,10 @@ net.Receive("TTTTargetHit", function(len, ply)
 			net.WriteBool(true)
 			net.Send(ply)
 		end
+	else
+		net.Start("TTTTargetHit")
+		net.Write(Target[ply])
+		net.WriteBool(false)
+		net.Send(ply)
 	end
 end)


### PR DESCRIPTION
Nach dieser Änderung wird häufiger überprüft ob der Spieler auch wirklich das Ziel ist und mehrmals verhindert, dass weitere Spieler in TargetPly einen anderen Spieler stehen haben, obwohl dieser sie wiederum nicht in Target hat. Dadurch sollte sich das Ziel nicht mehr ändern.