### PR TITLE
ConVar added to allow players to choose wether or not a spy should be able to be a hitmans target

### DIFF
--- a/lua/autorun/server/sv_hitman_target.lua
+++ b/lua/autorun/server/sv_hitman_target.lua
@@ -6,7 +6,7 @@ local function GetTargets(ply)
 	if not IsValid(ply) or not ply:IsActive() or not ply:Alive() or ply.IsGhost and ply:IsGhost() or ply:GetSubRole() ~= ROLE_HITMAN then
 		return targets
 	end
-		
+	
 	for _, pl in ipairs(player.GetAll()) do
 		if not GetConVar("ttt2_hitman_target_can_be_spy"):GetBool() then
 			if pl:Alive() and pl:IsActive() and not pl:IsInTeam(ply) and (not pl.IsGhost or not pl:IsGhost()) and (not JESTER or not pl:IsRole(ROLE_JESTER)) and (not SPY or not pl:IsRole(ROLE_SPY)) then

--- a/lua/autorun/server/sv_hitman_target.lua
+++ b/lua/autorun/server/sv_hitman_target.lua
@@ -6,8 +6,6 @@ local function GetTargets(ply)
 	if not IsValid(ply) or not ply:IsActive() or not ply:Alive() or ply.IsGhost and ply:IsGhost() or ply:GetSubRole() ~= ROLE_HITMAN then
 		return targets
 	end
-	
-		
 		
 	for _, pl in ipairs(player.GetAll()) do
 		if not GetConVar("ttt2_hitman_target_can_be_spy"):GetBool() then
@@ -28,7 +26,6 @@ local function GetTargets(ply)
 			end
 		end
 	end
-
 
 	if #targets < 1 then
 		targets = detes

--- a/lua/autorun/server/sv_hitman_target.lua
+++ b/lua/autorun/server/sv_hitman_target.lua
@@ -8,7 +8,7 @@ local function GetTargets(ply)
 	end
 
 	for _, pl in ipairs(player.GetAll()) do
-		if pl:Alive() and pl:IsActive() and not pl:IsInTeam(ply) and (not pl.IsGhost or not pl:IsGhost()) and (not JESTER or not pl:IsRole(ROLE_JESTER)) then
+		if pl:Alive() and pl:IsActive() and not pl:IsInTeam(ply) and (not pl.IsGhost or not pl:IsGhost()) and (not JESTER or not pl:IsRole(ROLE_JESTER)) and (not SPY or not pl:IsRole(ROLE_SPY)) then
 			if pl:IsRole(ROLE_DETECTIVE) then
 				detes[#detes + 1] = pl
 			else

--- a/lua/autorun/server/sv_hitman_target.lua
+++ b/lua/autorun/server/sv_hitman_target.lua
@@ -6,16 +6,29 @@ local function GetTargets(ply)
 	if not IsValid(ply) or not ply:IsActive() or not ply:Alive() or ply.IsGhost and ply:IsGhost() or ply:GetSubRole() ~= ROLE_HITMAN then
 		return targets
 	end
-
+	
+		
+		
 	for _, pl in ipairs(player.GetAll()) do
-		if pl:Alive() and pl:IsActive() and not pl:IsInTeam(ply) and (not pl.IsGhost or not pl:IsGhost()) and (not JESTER or not pl:IsRole(ROLE_JESTER)) and (not SPY or not pl:IsRole(ROLE_SPY)) then
-			if pl:IsRole(ROLE_DETECTIVE) then
-				detes[#detes + 1] = pl
-			else
-				targets[#targets + 1] = pl
+		if not GetConVar("ttt2_hitman_target_can_be_spy"):GetBool() then
+			if pl:Alive() and pl:IsActive() and not pl:IsInTeam(ply) and (not pl.IsGhost or not pl:IsGhost()) and (not JESTER or not pl:IsRole(ROLE_JESTER)) and (not SPY or not pl:IsRole(ROLE_SPY)) then
+				if pl:IsRole(ROLE_DETECTIVE) then
+					detes[#detes + 1] = pl
+				else
+					targets[#targets + 1] = pl
+				end
+			end
+		elseif GetConVar("ttt2_hitman_target_can_be_spy"):GetBool() then
+			if pl:Alive() and pl:IsActive() and not pl:IsInTeam(ply) and (not pl.IsGhost or not pl:IsGhost()) and (not JESTER or not pl:IsRole(ROLE_JESTER)) then
+				if pl:IsRole(ROLE_DETECTIVE) then
+					detes[#detes + 1] = pl
+				else
+					targets[#targets + 1] = pl
+				end
 			end
 		end
 	end
+
 
 	if #targets < 1 then
 		targets = detes

--- a/lua/autorun/sh_hitman_convars.lua
+++ b/lua/autorun/sh_hitman_convars.lua
@@ -1,5 +1,6 @@
 CreateConVar("ttt2_hitman_target_credit_bonus", 1, {FCVAR_ARCHIVE, FCVAR_NOTIFY})
 CreateConVar("ttt2_hitman_target_chatreveal", 0, {FCVAR_ARCHIVE, FCVAR_NOTIFY})
+CreateConVar("ttt2_hitman_target_can_be_spy", 0, {FCVAR_ARCHIVE, FCVAR_NOTIFY})
 
 hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_hitman_convars", function(tbl)
 	tbl[ROLE_HITMAN] = tbl[ROLE_HITMAN] or {}
@@ -17,5 +18,11 @@ hook.Add("TTTUlxDynamicRCVars", "ttt2_ulx_dynamic_hitman_convars", function(tbl)
 		cvar = "ttt2_hitman_target_chatreveal",
 		checkbox = true,
 		desc = "ttt2_hitman_target_chatreveal (def. 0)"
+	})
+	
+	table.insert(tbl[ROLE_HITMAN], {
+		cvar = "ttt2_hitman_target_can_be_spy",
+		checkbox = true,
+		desc = "ttt2_hitman_target_can_be_spy (def. 0)"
 	})
 end)


### PR DESCRIPTION
The ability to remove the spy from becoming a hitmans target was requested by some users. I added a ConVar instead of hardcoding it, so players that liked the old behaviour can still use it.

ConVar: ttt2_hitman_target_can_be_spy (def. 0)